### PR TITLE
BTAT-8323 Error hints do not follow pattern

### DIFF
--- a/app/views/agent/CapturePreferenceView.scala.html
+++ b/app/views/agent/CapturePreferenceView.scala.html
@@ -14,87 +14,89 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.play.views.html.helpers.{FormWithCSRF, ErrorSummary}
 @import config.AppConfig
 @import models.PreferenceModel
 @import forms.PreferenceForm._
+@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+@import views.html.templates.errors.ErrorSummary
 @import views.html.templates.inputs.{OptionRevealHelper, Text}
 
 @this(mainTemplate: MainTemplate,
-        formWithCSRF: FormWithCSRF,
-        errorSummary: ErrorSummary,
-        text: Text,
-        optionRevealHelper: OptionRevealHelper)
-
-
+      formWithCSRF: FormWithCSRF,
+      errorSummary: ErrorSummary,
+      text: Text,
+      optionRevealHelper: OptionRevealHelper)
 
 @(preferenceForm: Form[PreferenceModel])(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @content = {<p><strong class="bold">@messages("capturePref.confirmationEmailRequest")</strong></p>}
 
 @additionalContent = {
-    <span class="form-field">@messages("capturePref.email")</span>
-    <span class="form-hint">@messages("capturePref.email.hint")</span>
+  <span class="form-field">@messages("capturePref.email")</span>
+  <span class="form-hint">@messages("capturePref.email.hint")</span>
 }
 
 @additionalContentAlternative = {
-<span class="form-field">@messages("capturePref.email")</span>
-<span class="form-hint">@messages("capturePref.email.hintAlternative")</span>
+  <span class="form-field">@messages("capturePref.email")</span>
+  <span class="form-hint">@messages("capturePref.email.hintAlternative")</span>
 }
 
 @defining(if (appConfig.features.disableBulkPaper()) messages("capturePref.noLetterTitle") else messages("capturePref.title")) { pageTitle  =>
-@mainTemplate(if(preferenceForm.errors.nonEmpty) messages("common.error.prefixTitle", pageTitle) else pageTitle) {
 
-  <a class="link-back" href='@controllers.agent.routes.AgentHubController.show()'>@messages("base.back")</a>
+  @mainTemplate(if(preferenceForm.errors.nonEmpty) messages("common.error.prefixTitle", pageTitle) else pageTitle) {
 
-  @errorSummary(messages("common.error.heading"), preferenceForm, forceDivToAppear = false)
+    <a class="link-back" href='@controllers.agent.routes.AgentHubController.show()'>@messages("base.back")</a>
 
-@if(appConfig.features.disableBulkPaper()) {
+    @errorSummary(messages("common.error.heading"), preferenceForm)
 
-@formWithCSRF(action = controllers.agent.routes.CapturePreferenceController.submit) {
-<div id="@yesNo" class="link-bottom-margin">
-    @optionRevealHelper(
-    choices = Seq(
-    (yes, messages("common.yes")),
-    (no,  messages("common.no"))),
-    hiddenContent = text(preferenceForm(email),
-        additionalContent = Some(additionalContentAlternative)),
-    field          = preferenceForm(yesNo),
-    question       = messages("capturePref.noLetterTitle"),
-    inline         = false,
-    legendAsHeader = false,
-    subtext = Some(messages("capturePref.confirmationEmail")),
-    additionalContent = Some(content),
-    hiddenContentError = preferenceForm(email).hasErrors
-    )
-</div>
+    @if(appConfig.features.disableBulkPaper()) {
 
-<div class="form-group">
-    <button class="button" type="submit">@messages("common.continue")</button>
-</div>
-}
-} else {
+      @formWithCSRF(action = controllers.agent.routes.CapturePreferenceController.submit) {
+        <div id="@yesNo" class="link-bottom-margin">
+          @optionRevealHelper(
+          choices = Seq(
+            (yes, messages("common.yes")),
+            (no,  messages("common.no"))
+          ),
+          hiddenContent = text(preferenceForm(email),
+          additionalContent = Some(additionalContentAlternative)),
+          field          = preferenceForm(yesNo),
+          question       = messages("capturePref.noLetterTitle"),
+          inline         = false,
+          legendAsHeader = false,
+          subtext = Some(messages("capturePref.confirmationEmail")),
+          additionalContent = Some(content),
+          hiddenContentError = preferenceForm(email).hasErrors
+          )
+        </div>
 
-@formWithCSRF(action = controllers.agent.routes.CapturePreferenceController.submit) {
-<div id="@yesNo" class="link-bottom-margin">
-    @optionRevealHelper(
-    choices = Seq(
-    (yes, messages("common.yes")),
-    (no,  messages("common.no"))),
-    hiddenContent = text(preferenceForm(email),
-        additionalContent = Some(additionalContent)),
-    field          = preferenceForm(yesNo),
-    question       = messages("capturePref.title"),
-    inline         = false,
-    legendAsHeader = false,
-    subtext = Some(messages("capturePref.message"))
-    )
-</div>
+        <div class="form-group">
+          <button class="button" type="submit">@messages("common.continue")</button>
+        </div>
+      }
+    } else {
 
-<div class="form-group">
-    <button class="button" type="submit">@messages("common.continue")</button>
-</div>
-}
-}
-}
+      @formWithCSRF(action = controllers.agent.routes.CapturePreferenceController.submit) {
+        <div id="@yesNo" class="link-bottom-margin">
+          @optionRevealHelper(
+          choices = Seq(
+            (yes, messages("common.yes")),
+            (no,  messages("common.no"))
+          ),
+          hiddenContent = text(preferenceForm(email),
+          additionalContent = Some(additionalContent)),
+          field          = preferenceForm(yesNo),
+          question       = messages("capturePref.title"),
+          inline         = false,
+          legendAsHeader = false,
+          subtext = Some(messages("capturePref.message"))
+          )
+        </div>
+
+        <div class="form-group">
+          <button class="button" type="submit">@messages("common.continue")</button>
+        </div>
+      }
+    }
+  }
 }

--- a/app/views/agent/CapturePreferenceView.scala.html
+++ b/app/views/agent/CapturePreferenceView.scala.html
@@ -33,12 +33,12 @@
 
 @additionalContent = {
   <span class="form-field">@messages("capturePref.email")</span>
-  <span class="form-hint">@messages("capturePref.email.hint")</span>
+  <span id="form-hint" class="form-hint">@messages("capturePref.email.hint")</span>
 }
 
 @additionalContentAlternative = {
   <span class="form-field">@messages("capturePref.email")</span>
-  <span class="form-hint">@messages("capturePref.email.hintAlternative")</span>
+  <span id="form-hint" class="form-hint">@messages("capturePref.email.hintAlternative")</span>
 }
 
 @defining(if (appConfig.features.disableBulkPaper()) messages("capturePref.noLetterTitle") else messages("capturePref.title")) { pageTitle  =>
@@ -52,8 +52,7 @@
     @if(appConfig.features.disableBulkPaper()) {
 
       @formWithCSRF(action = controllers.agent.routes.CapturePreferenceController.submit) {
-        <div id="@yesNo" class="link-bottom-margin">
-          @optionRevealHelper(
+        @optionRevealHelper(
           choices = Seq(
             (yes, messages("common.yes")),
             (no,  messages("common.no"))
@@ -67,8 +66,7 @@
           subtext = Some(messages("capturePref.confirmationEmail")),
           additionalContent = Some(content),
           hiddenContentError = preferenceForm(email).hasErrors
-          )
-        </div>
+        )
 
         <div class="form-group">
           <button class="button" type="submit">@messages("common.continue")</button>
@@ -77,8 +75,7 @@
     } else {
 
       @formWithCSRF(action = controllers.agent.routes.CapturePreferenceController.submit) {
-        <div id="@yesNo" class="link-bottom-margin">
-          @optionRevealHelper(
+        @optionRevealHelper(
           choices = Seq(
             (yes, messages("common.yes")),
             (no,  messages("common.no"))
@@ -90,8 +87,7 @@
           inline         = false,
           legendAsHeader = false,
           subtext = Some(messages("capturePref.message"))
-          )
-        </div>
+        )
 
         <div class="form-group">
           <button class="button" type="submit">@messages("common.continue")</button>

--- a/app/views/agent/SelectClientVrnView.scala.html
+++ b/app/views/agent/SelectClientVrnView.scala.html
@@ -17,12 +17,10 @@
 @import views.html.templates.inputs.Text
 @import models.agent.ClientVrnModel
 @import play.api.data.Form
-@import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary, FormWithCSRF}
+@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+@import views.html.templates.errors.ErrorSummary
 
-@this(mainTemplate: MainTemplate,
-        formWithCSRF: FormWithCSRF,
-        errorSummary: ErrorSummary,
-        text: Text)
+@this(mainTemplate: MainTemplate, formWithCSRF: FormWithCSRF, errorSummary: ErrorSummary, text: Text)
 
 @(form: Form[ClientVrnModel])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
@@ -37,7 +35,7 @@
     if(form.errors.nonEmpty) messages("common.error.prefixTitle", messages("clientsVrn.heading")) else messages("clientsVrn.heading")
 ) {
 
-    @errorSummary(messages("common.error.heading"), form, forceDivToAppear = false)
+    @errorSummary(messages("common.error.heading"), form)
 
     @formWithCSRF(action = controllers.agent.routes.SelectClientVrnController.submit) {
 
@@ -51,5 +49,4 @@
 
         <button class="button" type="submit">@messages("common.continue")</button>
     }
-
 }

--- a/app/views/agent/SelectClientVrnView.scala.html
+++ b/app/views/agent/SelectClientVrnView.scala.html
@@ -25,28 +25,26 @@
 @(form: Form[ClientVrnModel])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @additionalContent = {
-    <span id="vrn-hint" class="form-hint">
-        @messages("clientsVrn.p1")
-        @messages("clientsVrn.example")
-    </span>
+  <span id="form-hint" class="form-hint">
+    @messages("clientsVrn.p1")
+    @messages("clientsVrn.example")
+  </span>
 }
 
 @mainTemplate(
     if(form.errors.nonEmpty) messages("common.error.prefixTitle", messages("clientsVrn.heading")) else messages("clientsVrn.heading")
 ) {
 
-    @errorSummary(messages("common.error.heading"), form)
+  @errorSummary(messages("common.error.heading"), form)
 
-    @formWithCSRF(action = controllers.agent.routes.SelectClientVrnController.submit) {
+  @formWithCSRF(action = controllers.agent.routes.SelectClientVrnController.submit) {
 
-        <div class="form-group">
-            @text(
-                form("vrn"),
-                Some(messages("clientsVrn.heading")),
-                Some(additionalContent)
-            )
-        </div>
+    @text(
+      form("vrn"),
+      Some(messages("clientsVrn.heading")),
+      Some(additionalContent)
+    )
 
-        <button class="button" type="submit">@messages("common.continue")</button>
-    }
+    <button class="button" type="submit">@messages("common.continue")</button>
+  }
 }

--- a/app/views/agent/WhatToDoView.scala.html
+++ b/app/views/agent/WhatToDoView.scala.html
@@ -14,57 +14,49 @@
  * limitations under the License.
  *@
 
-@import config.AppConfig
-@import templates.inputs.RadioHelper
-@import models.agent.WhatToDoModel
-@import forms.WhatToDoForm._
-@import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary, FormWithCSRF}
-
 @import common.MandationStatus
+@import config.AppConfig
+@import forms.WhatToDoForm._
+@import models.agent.WhatToDoModel
+@import templates.inputs.RadioHelper
+@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+@import views.html.templates.errors.ErrorSummary
 
-@this(mainTemplate: MainTemplate,
-        errorSummary: ErrorSummary,
-        formWithCSRF: FormWithCSRF,
-        radioHelper: RadioHelper)
+@this(mainTemplate: MainTemplate, errorSummary: ErrorSummary, formWithCSRF: FormWithCSRF, radioHelper: RadioHelper)
 
 @(form: Form[WhatToDoModel], name: String, mandationStatus: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @validChoices = @{
     Seq(
-        if(mandationStatus == MandationStatus.nonMTDfB) Some((submitReturn, Messages("whatToDo.submitReturn"))) else None
+        if(mandationStatus == MandationStatus.nonMTDfB) Some((submitReturn, messages("whatToDo.submitReturn"))) else None
     ).flatten ++
             Seq(
-                (viewReturn, Messages("whatToDo.viewReturns")),
-                (changeDetails, Messages("whatToDo.changeDetails")),
-                (viewCertificate, Messages("whatToDo.viewCertificate"))
+                (viewReturn, messages("whatToDo.viewReturns")),
+                (changeDetails, messages("whatToDo.changeDetails")),
+                (viewCertificate, messages("whatToDo.viewCertificate"))
             )
 }
 
 @mainTemplate(
     if(form.errors.nonEmpty) messages("common.error.prefixTitle", messages("whatToDo.heading", name)) else messages("whatToDo.heading", name),
-    bodyClasses = None
 ) {
 
-    @formWithCSRF(action = controllers.agent.routes.WhatToDoController.submit) {
+  @errorSummary(messages("common.error.heading"), form)
 
-        <div class="form-group" id="option">
+  @formWithCSRF(action = controllers.agent.routes.WhatToDoController.submit) {
 
-            @if(form.errors.nonEmpty) {
-                @errorSummary(messages("common.error.heading"), form)
-            }
+    <div class="form-group" id="option">
+        @radioHelper(
+            field = form("option"),
+            choices = validChoices,
+            question = messages("whatToDo.heading", name)
+        )
+    </div>
 
-            @radioHelper(
-                field = form("option"),
-                choices = validChoices,
-                question = Messages("whatToDo.heading", name)
-            )
-        </div>
-
-        <button class="button"
-            type ="submit"
-            id="continue">
-            @messages("common.continue")
-        </button>
-    }
-
+    <button class="button"
+        type ="submit"
+        id="continue">
+        @messages("common.continue")
+    </button>
+  }
 }

--- a/app/views/agent/WhatToDoView.scala.html
+++ b/app/views/agent/WhatToDoView.scala.html
@@ -38,7 +38,7 @@
 }
 
 @mainTemplate(
-    if(form.errors.nonEmpty) messages("common.error.prefixTitle", messages("whatToDo.heading", name)) else messages("whatToDo.heading", name),
+    if(form.errors.nonEmpty) messages("common.error.prefixTitle", messages("whatToDo.heading", name)) else messages("whatToDo.heading", name)
 ) {
 
   @errorSummary(messages("common.error.heading"), form)

--- a/app/views/templates/errors/ErrorSummary.scala.html
+++ b/app/views/templates/errors/ErrorSummary.scala.html
@@ -1,0 +1,41 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(heading: String, form: Form[_])(implicit messages: Messages)
+
+@if(form.hasErrors) {
+
+  <div class="flash error-summary@if(form.hasErrors) { error-summary--show}"
+       id="error-summary-display"
+       role="alert"
+       aria-labelledby="error-summary-heading"
+       tabindex="-1">
+    <h2 id="error-summary-heading" class="h3-heading">@messages(heading)</h2>
+    <ul class="js-error-summary-messages">
+    @form.errors.map { error =>
+      <li class="error-summary-list">
+        <a href="#@error.key"
+        id="@{error.key}-error-summary"
+        data-focuses="@{error.key}">
+        @messages(error.message, error.args: _*)
+        </a>
+      </li>
+    }
+    </ul>
+  </div>
+}

--- a/app/views/templates/inputs/OptionRevealHelper.scala.html
+++ b/app/views/templates/inputs/OptionRevealHelper.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import forms.PreferenceForm.yesNo
 @import views.html.helper._
 
 @this()
@@ -25,49 +26,58 @@
   hiddenContent: Html,
   legendAsHeader: Boolean = true,
   subtext: Option[String] = None,
-    additionalContent: Option[Html] = None,
-    hiddenContentError: Boolean = false
+  additionalContent: Option[Html] = None,
+  hiddenContentError: Boolean = false
 )(implicit messages: Messages)
 
 @elements = @{ FieldElements(field.id, field, null, Map(), messages) }
 
-<div @if(elements.hasErrors){ class="form-field--error"}>
-  <fieldset>
-    <legend>
-      <h1>@question</h1>
-    </legend>
+<div id="@yesNo" class="form-group">
 
-    @subtext.map { text =>
-      <p>@text</p>
-    }
+  <fieldset aria-describedby="form-hint@if(field.hasErrors){ form-error}">
 
-    @additionalContent.map { content =>
-      @content
-     }
+    <div class="form-field@if(elements.hasErrors){--error panel-border-narrow}">
+      <legend>
+        <h1>@question</h1>
+      </legend>
 
-    @elements.errors.map { error => <span class="error-message">@messages(error)</span> }
+      @subtext.map { text =>
+        <p>@text</p>
+      }
 
-    <div @if(inline){ class="inline"}>
-      <div class="multiple-choice" data-target="hiddenContent">
-        <input type="radio" id="@{elements.field.name}-yes"
-               name="@elements.field.name" value="yes"
-               @field.value.filter( _ == "yes").map{_ => checked="checked"}/>
+      @additionalContent.map { content =>
+        @content
+      }
 
-        <label for="@{elements.field.name}-yes" id="label-@{elements.field.name}-yes">@messages("common.yes")</label>
-      </div>
+      @elements.errors.map { error =>
+        <span id="form-error" class="error-message">
+          <span class="visuallyhidden">@messages("common.error")</span>
+          @messages(error)
+        </span>
+      }
 
-        <div class="form-group panel panel-border-narrow @if(field.value != Some("yes")){js-hidden} @if(hiddenContentError){hidden-error-panel}" id="hiddenContent">
-        @hiddenContent
+      <div @if(inline){ class="inline"}>
+        <div class="multiple-choice" data-target="hiddenContent">
+          <input type="radio" id="@{elements.field.name}-yes"
+                 name="@elements.field.name" value="yes"
+                 @field.value.filter( _ == "yes").map{_ => checked="checked"}/>
+
+          <label for="@{elements.field.name}-yes" id="label-@{elements.field.name}-yes">@messages("common.yes")</label>
         </div>
 
-      <div class="multiple-choice">
-        <input type="radio"
-               id="@{elements.field.name}-no" name="@elements.field.name" value="no"
-               @field.value.filter( _ == "no").map{_ => checked="checked"}/>
-        <label for="@{elements.field.name}-no" id="label-@{elements.field.name}-no">@messages("common.no")</label>
+          <div class="form-group panel panel-border-narrow @if(!field.value.contains("yes")){js-hidden} @if(hiddenContentError){hidden-error-panel}" id="hiddenContent">
+            @hiddenContent
+          </div>
+
+        <div class="multiple-choice">
+          <input type="radio"
+                 id="@{elements.field.name}-no"
+                 name="@elements.field.name"
+                 value="no"
+                 @field.value.filter( _ == "no").map{_ => checked="checked"}/>
+          <label for="@{elements.field.name}-no" id="label-@{elements.field.name}-no">@messages("common.no")</label>
+        </div>
       </div>
     </div>
   </fieldset>
-
-
 </div>

--- a/app/views/templates/inputs/Text.scala.html
+++ b/app/views/templates/inputs/Text.scala.html
@@ -20,14 +20,14 @@
 
 <div class="form-field@if(field.hasErrors){--error}">
 
-    @if(!heading.isEmpty){<h1>@heading</h1>}
+  @if(!heading.isEmpty){<h1>@heading</h1>}
 
   @additionalContent.map { content => @content }
 
   <label for="@field.id" class="form-label visuallyhidden">@heading</label>
 
   @field.errors.headOption.map { error =>
-    <span class="error-message" role="tooltip">
+    <span class="error-message">
       @messages(error.message, error.args: _*)
     </span>
   }

--- a/app/views/templates/inputs/Text.scala.html
+++ b/app/views/templates/inputs/Text.scala.html
@@ -18,23 +18,30 @@
 
 @(field: Field, heading: Option[String] = None, additionalContent: Option[Html] = None)(implicit messages: Messages)
 
-<div class="form-field@if(field.hasErrors){--error}">
+<div class="form-group">
 
-  @if(!heading.isEmpty){<h1>@heading</h1>}
+  <fieldset aria-describedby="form-hint@if(field.hasErrors){ form-error}">
 
-  @additionalContent.map { content => @content }
+    <div class="form-field@if(field.hasErrors){--error panel-border-narrow}">
 
-  <label for="@field.id" class="form-label visuallyhidden">@heading</label>
+      @heading.map { title =>
+        <h1 id="page-heading"><label for="@field.id" class="heading-large">@messages(title)</label></h1>
+      }
 
-  @field.errors.headOption.map { error =>
-    <span class="error-message">
-      @messages(error.message, error.args: _*)
-    </span>
-  }
+      @additionalContent.map { content => @content }
 
-  <input type="text"
-         class="form-control input--no-spinner"
-         name="@field.name"
-         id="@field.name"
-         value="@field.value.getOrElse("")"/>
+      @field.errors.headOption.map { error =>
+        <span id="form-error" class="error-message">
+          <span class="visuallyhidden">@messages("common.error")</span>
+          @messages(error.message, error.args: _*)
+        </span>
+      }
+
+      <input type="text"
+             class="form-control input--no-spinner"
+             name="@field.name"
+             id="@field.name"
+             value="@field.value.getOrElse("")"/>
+    </div>
+  </fieldset>
 </div>

--- a/conf/messages
+++ b/conf/messages
@@ -4,6 +4,7 @@ base.pageTitle = {0} - {1} - GOV.UK
 
 common.yes = Yes
 common.no = No
+common.error = Error:
 common.error.heading = There is a problem
 common.error.prefixTitle = Error: {0}
 common.differentClient = Make changes for a different client

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -4,6 +4,7 @@ base.pageTitle = {0} - {1} - GOV.UK
 
 common.yes = Iawn
 common.no = Na
+common.error = Gwall:
 common.error.heading = Mae problem wedi codi
 common.error.prefixTitle = Gwall: {0}
 common.differentClient = Gwneud newidiadau ar gyfer cleient gwahanol

--- a/it/pages/agent/SelectClientVrnPageSpec.scala
+++ b/it/pages/agent/SelectClientVrnPageSpec.scala
@@ -176,7 +176,7 @@ class SelectClientVrnPageSpec extends BasePageISpec {
 
               //Error against Input Label
               isElementVisible(".form-field--error .error-message")(isVisible = true),
-              elementText(".form-field--error .error-message")("Enter a VAT number in the correct format")
+              elementText(".form-field--error .error-message")("Error: Enter a VAT number in the correct format")
             )
           }
         }

--- a/test/views/agent/CapturePreferenceViewSpec.scala
+++ b/test/views/agent/CapturePreferenceViewSpec.scala
@@ -27,11 +27,11 @@ class CapturePreferenceViewSpec extends ViewBaseSpec {
 
   object Selectors {
     val pageHeading         = "#content h1"
-    val subtext             = "fieldset > p"
-    val additionalContent   = "fieldset > p:nth-of-type(2)"
+    val subtext             = ".form-field > p:nth-child(2)"
+    val inlineQuestion      = ".bold"
     val backLink            = ".link-back"
-    val emailQuestionText   = "#hiddenContent > div > span.form-field"
-    val emailHintText       = "#hiddenContent > div > span.form-hint"
+    val emailQuestionText   = "span.form-field"
+    val emailHintText       = "span.form-hint"
     val form                = "form"
     val emailField          = "#email"
     val continueButton      = "button"
@@ -43,14 +43,11 @@ class CapturePreferenceViewSpec extends ViewBaseSpec {
     val emailFormGroup      = "#hiddenContent"
   }
 
-
   val injectedView: CapturePreferenceView = inject[CapturePreferenceView]
 
   "Rendering the capture preference page" when {
 
     "the feature switch disable Bulk Paper is turned on" when {
-
-
 
       "the form has no errors" when {
 
@@ -85,6 +82,10 @@ class CapturePreferenceViewSpec extends ViewBaseSpec {
           "have the correct subtext" in {
             elementText(Selectors.subtext) shouldBe
               "We now confirm changes by email. We’ll contact your client with an update."
+          }
+
+          "have the correct inline question" in {
+            elementText(Selectors.inlineQuestion) shouldBe "Do you want us to send you an email to confirm changes you make?"
           }
 
           "have the preference form with the correct form action" in {

--- a/test/views/agent/SelectClientVrnViewSpec.scala
+++ b/test/views/agent/SelectClientVrnViewSpec.scala
@@ -93,7 +93,7 @@ class SelectClientVrnViewSpec extends ViewBaseSpec {
       }
 
       "have the correct error notification text above the input box" in {
-        elementText(".error-message") shouldBe viewMessages.formErrorInvalidVrn
+        elementText(".error-message") shouldBe s"Error: ${viewMessages.formErrorInvalidVrn}"
       }
     }
   }

--- a/test/views/templates/errors/ErrorSummarySpec.scala
+++ b/test/views/templates/errors/ErrorSummarySpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.templates.errors
+
+import forms.ClientVrnForm
+import models.agent.ClientVrnModel
+import play.api.data.Form
+import play.twirl.api.Html
+import views.html.templates.errors.ErrorSummary
+import views.templates.TemplateBaseSpec
+
+class ErrorSummarySpec extends TemplateBaseSpec {
+
+  val injectedView: ErrorSummary = inject[ErrorSummary]
+  val form: Form[ClientVrnModel] = ClientVrnForm.form
+  val formWithError: Form[ClientVrnModel] = ClientVrnForm.form.bind(Map("vrn" -> "6"))
+
+  "ErrorSummary" when {
+
+    "the form has errors" should {
+
+      "render the correct Html" in {
+
+        val expectedMarkup = Html(
+          s"""
+             |<div class="flash error-summary error-summary--show" id="error-summary-display" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+             |  <h2 id="error-summary-heading" class="h3-heading">heading</h2>
+             |  <ul class="js-error-summary-messages">
+             |    <li class="error-summary-list"> <a href="#vrn" id="vrn-error-summary" data-focuses="vrn"> Enter a VAT number in the correct format </a> </li>
+             |  </ul>
+             |</div>
+           """.stripMargin
+        )
+
+        val result = injectedView("heading", formWithError)
+
+        formatHtml(result) shouldBe formatHtml(expectedMarkup)
+      }
+    }
+
+    "the form has no errors" should {
+
+      "return nothing" in {
+
+        val result = injectedView("heading", form)
+
+        formatHtml(result) shouldBe formatHtml(Html(""))
+      }
+    }
+  }
+}

--- a/test/views/templates/inputs/TextTemplateSpec.scala
+++ b/test/views/templates/inputs/TextTemplateSpec.scala
@@ -92,7 +92,7 @@ class TextTemplateSpec extends TemplateBaseSpec {
            |  <h1>labelText</h1>
            |  <p>Content</p>
            |  <label for="$fieldName" class="form-label visuallyhidden">labelText</label>
-           |  <span class="error-message" role="tooltip">
+           |  <span class="error-message">
            |    $errorMessage
            |  </span>
            |  <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value=""/>

--- a/test/views/templates/inputs/TextTemplateSpec.scala
+++ b/test/views/templates/inputs/TextTemplateSpec.scala
@@ -39,13 +39,14 @@ class TextTemplateSpec extends TemplateBaseSpec {
 
       val expectedMarkup = Html(
         s"""
-           |
-           |<div class="form-field">
-           |  <h1>labelText</h1>
-           |  <label for="$fieldName" class="form-label visuallyhidden">labelText</label>
-           |  <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value=""/>
+           |<div class="form-group">
+           |  <fieldset aria-describedby="form-hint">
+           |    <div class="form-field">
+           |      <h1 id="page-heading"><label for=$fieldName class="heading-large">labelText</label></h1>
+           |      <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value=""/>
+           |    </div>
+           |  </fieldset>
            |</div>
-           |
         """.stripMargin
       )
 
@@ -63,14 +64,15 @@ class TextTemplateSpec extends TemplateBaseSpec {
 
       val expectedMarkup = Html(
         s"""
-           |
-           |<div class="form-field">
-           |  <h1>labelText</h1>
-           |  <p>Content</p>
-           |  <label for="$fieldName" class="form-label visuallyhidden">labelText</label>
-           |  <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="$value"/>
+           |<div class="form-group">
+           |  <fieldset aria-describedby="form-hint">
+           |    <div class="form-field">
+           |      <h1 id="page-heading"><label for=$fieldName class="heading-large">labelText</label></h1>
+           |      <p>Content</p>
+           |      <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="$value"/>
+           |    </div>
+           |  </fieldset>
            |</div>
-           |
         """.stripMargin
       )
 
@@ -87,17 +89,19 @@ class TextTemplateSpec extends TemplateBaseSpec {
 
       val expectedMarkup = Html(
         s"""
-           |
-           |<div class="form-field--error">
-           |  <h1>labelText</h1>
-           |  <p>Content</p>
-           |  <label for="$fieldName" class="form-label visuallyhidden">labelText</label>
-           |  <span class="error-message">
-           |    $errorMessage
-           |  </span>
-           |  <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value=""/>
+           |<div class="form-group">
+           |  <fieldset aria-describedby="form-hint form-error">
+           |    <div class="form-field--error panel-border-narrow">
+           |      <h1 id="page-heading"><label for=$fieldName class="heading-large">labelText</label></h1>
+           |      <p>Content</p>
+           |      <span id="form-error" class="error-message">
+           |        <span class="visuallyhidden">Error:</span>
+           |        $errorMessage
+           |      </span>
+           |      <input type="text" class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value=""/>
+           |    </div>
+           |  </fieldset>
            |</div>
-           |
         """.stripMargin
       )
 


### PR DESCRIPTION
I did not apply any a11y fixes to the `RadioGroup` component, as this is only called by an unused view (the "agent action" page) which should be removed in the future as part of a feature switch removal task.