### PR TITLE
BTAT-8607 Added test-only route to retrieve passcode

### DIFF
--- a/app/testOnly/connectors/RetrievePasscodeConnector.scala
+++ b/app/testOnly/connectors/RetrievePasscodeConnector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.connectors
+
+import config.AppConfig
+import connectors.httpParsers.ResponseHttpParser.HttpResult
+import javax.inject.Inject
+import models.errors.UnexpectedError
+import play.api.Logger
+import play.api.http.Status
+import testOnly.models.Passcode
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class RetrievePasscodeConnector @Inject()(http: HttpClient, appConfig: AppConfig) {
+
+  val getPasscodeUrl: String = appConfig.emailVerificationBaseUrl + "/test-only/passcodes"
+
+  implicit object Reads extends HttpReads[HttpResult[Passcode]] {
+    override def read(method: String, url: String, response: HttpResponse): HttpResult[Passcode] =
+      response.status match {
+        case Status.OK => Right(response.json.as[Passcode])
+        case status =>
+          Logger.warn("[RetrievePasscodeConnector][read] - Failed to retrieve passcode. " +
+            s"Received status: $status. Received body: ${response.body}")
+          Left(UnexpectedError(status, response.body))
+      }
+  }
+
+  def getPasscode(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResult[Passcode]] =
+    http.GET(getPasscodeUrl)
+}

--- a/app/testOnly/controllers/RetrievePasscodeController.scala
+++ b/app/testOnly/controllers/RetrievePasscodeController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.controllers
+
+import config.ErrorHandler
+import javax.inject.{Inject, Singleton}
+import play.api.libs.json.JsString
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import testOnly.connectors.RetrievePasscodeConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class RetrievePasscodeController @Inject()(mcc: MessagesControllerComponents,
+                                           errorHandler: ErrorHandler,
+                                           connector: RetrievePasscodeConnector)
+                                          (implicit ec: ExecutionContext) extends FrontendController(mcc) {
+
+  def getPasscode: Action[AnyContent] = Action.async { implicit request =>
+    connector.getPasscode.map {
+      case Right(model) => Ok(JsString(model.passcode))
+      case _ => errorHandler.showInternalServerError
+    }
+  }
+}

--- a/app/testOnly/models/Passcode.scala
+++ b/app/testOnly/models/Passcode.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Passcode(passcode: String)
+
+object Passcode {
+  implicit val format: OFormat[Passcode] = Json.format[Passcode]
+}

--- a/conf/testOnly.routes
+++ b/conf/testOnly.routes
@@ -14,4 +14,6 @@
 GET        /vat-through-software/representative/test-only/feature-switch    @testOnly.controllers.FeatureSwitchController.featureSwitch
 POST       /vat-through-software/representative/test-only/feature-switch    @testOnly.controllers.FeatureSwitchController.submitFeatureSwitch
 
+GET        /vat-through-software/representative/test-only/passcode          @testOnly.controllers.RetrievePasscodeController.getPasscode
+
 ->         /                                                                prod.Routes


### PR DESCRIPTION
The passcode will be returned as a JsString. I've not been able to manually test it yet - until the wiring up is done, the email-verification service returns an error for this route as there is no passcode request for the session.