### PR TITLE
BTAT-9398 Refactor to DD interrupt code so every user gets session key

### DIFF
--- a/app/controllers/predicates/DDInterruptPredicate.scala
+++ b/app/controllers/predicates/DDInterruptPredicate.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import common.SessionKeys
+import controllers.Assets.Redirect
+import models.User
+import play.api.mvc.{ActionRefiner, Result}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class DDInterruptPredicate @Inject()(override val executionContext: ExecutionContext) extends ActionRefiner[User, User] {
+
+  override def refine[A](request: User[A]): Future[Either[Result, User[A]]] =
+    if(request.session.get(SessionKeys.viewedDDInterrupt).isDefined) {
+      Future.successful(Right(request))
+    } else {
+      Future.successful(Left(Redirect(controllers.agent.routes.DDInterruptController.show().url)))
+    }
+}

--- a/app/controllers/predicates/PreferencePredicate.scala
+++ b/app/controllers/predicates/PreferencePredicate.scala
@@ -20,15 +20,14 @@ import javax.inject.{Inject, Singleton}
 import common.SessionKeys
 import config.AppConfig
 import models.Agent
-import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
+import play.api.mvc.{ActionRefiner, Result}
 import play.api.mvc.Results.Redirect
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class PreferencePredicate @Inject()(mcc: MessagesControllerComponents,
-                                    implicit val appConfig: AppConfig,
-                                    implicit val executionContext: ExecutionContext) extends ActionRefiner[Agent, Agent] {
+class PreferencePredicate @Inject()(implicit val appConfig: AppConfig,
+                                    override val executionContext: ExecutionContext) extends ActionRefiner[Agent, Agent] {
 
   override def refine[A](request: Agent[A]): Future[Either[Result, Agent[A]]] = {
 

--- a/app/views/agent/DirectDebitInterruptView.scala.html
+++ b/app/views/agent/DirectDebitInterruptView.scala.html
@@ -38,7 +38,7 @@
     @messages("directDebitInterrupt.needToLogIn")
   </p>
 
-  @formWithCSRF(action = controllers.agent.routes.DDInterruptController.submit) {
+  @formWithCSRF(action = controllers.agent.routes.DDInterruptController.submit()) {
     <div class="form-group">
       @singleCheckbox(form("checkbox"), messages("directDebitInterrupt.iWillInform"))
     </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -26,6 +26,7 @@ GET        /send-passcode                               controllers.agent.Verify
 
 GET        /client-vat-account                          controllers.agent.AgentHubController.show
 
+GET        /direct-debit-interrupt                      controllers.agent.DDInterruptController.show
 POST       /direct-debit-interrupt                      controllers.agent.DDInterruptController.submit
 
 # Map static resources from the /public folder to the /assets URL path

--- a/test/controllers/agent/ConfirmClientVrnControllerSpec.scala
+++ b/test/controllers/agent/ConfirmClientVrnControllerSpec.scala
@@ -42,6 +42,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
 
   object TestConfirmClientVrnController extends ConfirmClientVrnController(
     mockAuthAsAgentWithClient,
+    mockDDPredicate,
     mockCustomerDetailsService,
     serviceErrorHandler,
     mockAuditingService,
@@ -290,6 +291,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           lazy val result = {
             TestConfirmClientVrnController.redirect(FakeRequest().withSession(
               SessionKeys.clientVRN -> vrn,
+              SessionKeys.viewedDDInterrupt -> "true",
               SessionKeys.redirectUrl -> "/vat-through-software/account/change-something-about-vat",
               SessionKeys.preference -> "no",
               SessionKeys.notificationsEmail -> "an.email@host.com"
@@ -320,6 +322,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           lazy val result = {
             TestConfirmClientVrnController.redirect(FakeRequest().withSession(
               SessionKeys.preference -> "yes",
+              SessionKeys.viewedDDInterrupt -> "true",
               SessionKeys.clientVRN -> vrn,
               SessionKeys.redirectUrl -> "/vat-through-software/account/change-something-about-vat",
               SessionKeys.verifiedAgentEmail -> "an.email@host.com"
@@ -351,6 +354,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
             TestConfirmClientVrnController.redirect(FakeRequest().withSession(
               SessionKeys.preference -> "yes",
               SessionKeys.clientVRN -> vrn,
+              SessionKeys.viewedDDInterrupt -> "true",
               SessionKeys.redirectUrl -> "/vat-through-software/account/change-something-about-vat"
             ))
           }
@@ -372,6 +376,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           lazy val result = {
             TestConfirmClientVrnController.redirect(FakeRequest().withSession(
               SessionKeys.clientVRN -> vrn,
+              SessionKeys.viewedDDInterrupt -> "true",
               SessionKeys.redirectUrl -> "/vat-through-software/account/change-something-about-vat"
             ))
           }
@@ -392,6 +397,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           lazy val result = {
             TestConfirmClientVrnController.redirect(FakeRequest().withSession(
               SessionKeys.clientVRN -> vrn,
+              SessionKeys.viewedDDInterrupt -> "true",
               SessionKeys.redirectUrl -> "/random-place"
             ))
           }
@@ -412,6 +418,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           lazy val result = {
             TestConfirmClientVrnController.redirect(FakeRequest().withSession(
               SessionKeys.clientVRN -> vrn,
+              SessionKeys.viewedDDInterrupt -> "true",
               SessionKeys.redirectUrl -> ""
             ))
           }
@@ -431,23 +438,43 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
 
     "redirect URL is not in session" should {
 
-        lazy val result = {
-          TestConfirmClientVrnController.redirect(FakeRequest().withSession(
-            SessionKeys.clientVRN -> vrn,
-            SessionKeys.notificationsEmail -> "an.email@host.com"
-          ))
-        }
+      lazy val result = {
+        TestConfirmClientVrnController.redirect(FakeRequest().withSession(
+          SessionKeys.clientVRN -> vrn,
+          SessionKeys.viewedDDInterrupt -> "true",
+          SessionKeys.notificationsEmail -> "an.email@host.com"
+        ))
+      }
 
-        "return status SEE_OTHER (303)" in {
-          mockAgentAuthorised()
-          mockCustomerDetailsSuccess(customerDetailsOrganisation)
-          status(result) shouldBe Status.SEE_OTHER
-        }
+      "return status SEE_OTHER (303)" in {
+        mockAgentAuthorised()
+        mockCustomerDetailsSuccess(customerDetailsOrganisation)
+        status(result) shouldBe Status.SEE_OTHER
+      }
 
-        "redirect to WhatToDo controller" in {
-          redirectLocation(result) shouldBe Some(controllers.agent.routes.AgentHubController.show().url)
-        }
+      "redirect to WhatToDo controller" in {
+        redirectLocation(result) shouldBe Some(controllers.agent.routes.AgentHubController.show().url)
+      }
+    }
 
+    "the DD interrupt value is not in session" should {
+
+      lazy val result = {
+        TestConfirmClientVrnController.redirect(FakeRequest().withSession(
+          SessionKeys.clientVRN -> vrn,
+          SessionKeys.notificationsEmail -> "an.email@host.com"
+        ))
+      }
+
+      "return status SEE_OTHER (303)" in {
+        mockAgentAuthorised()
+        mockCustomerDetailsSuccess(customerDetailsOrganisation)
+        status(result) shouldBe Status.SEE_OTHER
+      }
+
+      "redirect to the DD interrupt controller" in {
+        redirectLocation(result) shouldBe Some(controllers.agent.routes.DDInterruptController.show().url)
+      }
     }
   }
 }

--- a/test/controllers/predicates/DDInterruptPredicateSpec.scala
+++ b/test/controllers/predicates/DDInterruptPredicateSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import common.SessionKeys
+import controllers.Assets.Redirect
+import controllers.ControllerBaseSpec
+import models.User
+
+class DDInterruptPredicateSpec extends ControllerBaseSpec {
+
+  "The DDInterruptPredicate" should {
+
+    "allow the request to pass through when the user has the DD session value" in {
+      val userWithSession =
+        User("999999999", arn = Some("XARN1234567"))(request.withSession(SessionKeys.viewedDDInterrupt -> "true"))
+      await(mockDDPredicate.refine(userWithSession)) shouldBe Right(userWithSession)
+    }
+
+    "redirect the request to the DDInterruptController when the user does not have the DD session value" in {
+      await(mockDDPredicate.refine(user)) shouldBe Left(Redirect(controllers.agent.routes.DDInterruptController.show().url))
+    }
+  }
+}

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -65,6 +65,8 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar {
       ec
     )
 
+  val mockDDPredicate: DDInterruptPredicate = new DDInterruptPredicate(ec)
+
   val mockAgentOnlyAuthPredicate: AuthoriseAsAgentOnly =
     new AuthoriseAsAgentOnly(
       mockEnrolmentsAuthService,
@@ -75,11 +77,7 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar {
       mockConfig
     )
 
-  val mockPreferencePredicate: PreferencePredicate = new PreferencePredicate(
-    mcc,
-    mockConfig,
-    ec
-  )
+  val mockPreferencePredicate: PreferencePredicate = new PreferencePredicate
 
   def mockIndividualAuthorised(): OngoingStubbing[Future[~[Option[AffinityGroup], Enrolments]]] =
     setupAuthResponse(Future.successful(

--- a/test/views/agent/DirectDebitInterruptViewSpec.scala
+++ b/test/views/agent/DirectDebitInterruptViewSpec.scala
@@ -59,7 +59,7 @@ class DirectDebitInterruptViewSpec extends ViewBaseSpec {
       }
 
       "have the correct form action" in {
-        element("form").attr("action") shouldBe controllers.agent.routes.DDInterruptController.submit.url
+        element("form").attr("action") shouldBe controllers.agent.routes.DDInterruptController.submit().url
       }
 
       "have a button" which {


### PR DESCRIPTION
The code has essentially been shuffled around here so that the DD interrupt logic has been completely taken out of `AgentHubController`, and instead is split across the DD predicate and DD controller. Then, the predicate was added to an action in `ConfirmClientVrnController` to catch them immediately after confirming client details regardless of where they may be redirected (it's possible to bypass agent hub page).

This should hopefully make the code easier to follow as the DD logic is all contained in the relevant places, and it more closely resembles the solution in the client services.