### PR TITLE
BTAT-9913 Removed deprecated session keys

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -21,12 +21,8 @@ object SessionKeys {
   val clientVRNDeprecated: String = "CLIENT_VRN"
   val clientVRN: String = "mtdVatvcClientVrn"
 
-  val verifiedEmailDeprecated: String = "verifiedAgentEmail"
   val verifiedEmail: String = "mtdVatvcVerifiedAgentEmail"
-
-  val clientNameDeprecated: String = "mtdVatAgentClientName"
   val clientName: String = "mtdVatvcAgentClientName"
-
   val clientMandationStatus: String = "mtdVatMandationStatus"
   val redirectUrl: String = "vatAgentLookupRedirectUrl"
   val preference: String = "vatAgentLookupEmailPreference"

--- a/app/controllers/agent/ConfirmClientVrnController.scala
+++ b/app/controllers/agent/ConfirmClientVrnController.scala
@@ -60,10 +60,9 @@ class ConfirmClientVrnController @Inject()(authenticate: AuthoriseAsAgentWithCli
             Some(controllers.agent.routes.ConfirmClientVrnController.show.url)
           )
 
-          Ok(confirmClientVrnView(user.vrn, customerDetails)).addingToSession(
-            SessionKeys.clientNameDeprecated -> customerDetails.clientName,
-            SessionKeys.clientName -> customerDetails.clientName
-          )
+          Ok(confirmClientVrnView(user.vrn, customerDetails))
+            .addingToSession(SessionKeys.clientName -> customerDetails.clientName)
+
         case Left(Migration) => PreconditionFailed(accountMigrationView())
         case Left(NotSignedUp) => NotFound(notSignedUpView())
         case _ =>
@@ -77,8 +76,8 @@ class ConfirmClientVrnController @Inject()(authenticate: AuthoriseAsAgentWithCli
       val redirectUrl = user.session.get(SessionKeys.redirectUrl).getOrElse("")
 
       Redirect(controllers.agent.routes.SelectClientVrnController.show(redirectUrl))
-        .removingFromSession(SessionKeys.clientVRNDeprecated, SessionKeys.clientVRN, SessionKeys.viewedDDInterrupt,
-          SessionKeys.clientNameDeprecated, SessionKeys.clientName)
+        .removingFromSession(SessionKeys.clientVRNDeprecated, SessionKeys.clientVRN,
+                             SessionKeys.viewedDDInterrupt, SessionKeys.clientName)
   }
 
   def redirect: Action[AnyContent] = (authenticate andThen ddInterrupt) {
@@ -86,7 +85,7 @@ class ConfirmClientVrnController @Inject()(authenticate: AuthoriseAsAgentWithCli
     implicit user =>
 
       val redirectUrl = user.session.get(SessionKeys.redirectUrl)
-      val hasVerifiedAgentEmail: Boolean = user.session.get(SessionKeys.verifiedEmailDeprecated).isDefined
+      val hasVerifiedAgentEmail: Boolean = user.session.get(SessionKeys.verifiedEmail).isDefined
       val manageVatUrl = appConfig.manageVatCustomerDetailsUrl
 
       redirectUrl match {

--- a/app/controllers/agent/ConfirmEmailController.scala
+++ b/app/controllers/agent/ConfirmEmailController.scala
@@ -74,6 +74,6 @@ class ConfirmEmailController @Inject()(authenticate: AuthoriseAsAgentOnly,
       YesPreferenceVerifiedAuditModel(agent.arn, email),
       Some(controllers.agent.routes.ConfirmEmailController.isEmailVerified.url)
     )
-    Redirect(redirectUrl).addingToSession(SessionKeys.verifiedEmailDeprecated -> email, SessionKeys.verifiedEmail -> email)
+    Redirect(redirectUrl).addingToSession(SessionKeys.verifiedEmail -> email)
   }
 }

--- a/app/controllers/agent/VerifyEmailPinController.scala
+++ b/app/controllers/agent/VerifyEmailPinController.scala
@@ -68,7 +68,7 @@ class VerifyEmailPinController @Inject()(emailVerificationService: EmailVerifica
                 "Unable to send email verification request. Service responded with 'already verified'"
             )
             Redirect(agent.session.get(SessionKeys.redirectUrl).getOrElse(appConfig.manageVatCustomerDetailsUrl))
-              .addingToSession(SessionKeys.verifiedEmailDeprecated -> email, SessionKeys.verifiedEmail -> email)
+              .addingToSession(SessionKeys.verifiedEmail -> email)
           case _ => errorHandler.showInternalServerError
         }
       case _ => Future.successful(Redirect(routes.CapturePreferenceController.show()))
@@ -87,7 +87,7 @@ class VerifyEmailPinController @Inject()(emailVerificationService: EmailVerifica
             emailVerificationService.verifyPasscode(email, passcode).map {
               case Right(SuccessfullyVerified) | Right(AlreadyVerified) =>
                 Redirect(agent.session.get(SessionKeys.redirectUrl).getOrElse(appConfig.manageVatCustomerDetailsUrl))
-                  .addingToSession(SessionKeys.verifiedEmailDeprecated -> email, SessionKeys.verifiedEmail -> email)
+                  .addingToSession(SessionKeys.verifiedEmail -> email)
               case Right(TooManyAttempts) => BadRequest(incorrectPasscodeView("incorrectPasscode.tooManyAttempts"))
               case Right(PasscodeNotFound) => BadRequest(incorrectPasscodeView("incorrectPasscode.expired"))
               case Right(IncorrectPasscode) =>

--- a/app/controllers/predicates/PreferencePredicate.scala
+++ b/app/controllers/predicates/PreferencePredicate.scala
@@ -35,7 +35,7 @@ class PreferencePredicate @Inject()(implicit val appConfig: AppConfig,
 
     val redirectUrl = agent.session.get(SessionKeys.redirectUrl).getOrElse(appConfig.manageVatCustomerDetailsUrl)
     val preference = agent.session.get(SessionKeys.preference)
-    val hasVerifiedEmail = agent.session.get(SessionKeys.verifiedEmailDeprecated).isDefined
+    val hasVerifiedEmail = agent.session.get(SessionKeys.verifiedEmail).isDefined
 
       preference match {
         case Some("no") => Future.successful(Left(Redirect(redirectUrl)))

--- a/app/views/helpers/CapturePreferenceHelper.scala.html
+++ b/app/views/helpers/CapturePreferenceHelper.scala.html
@@ -21,7 +21,7 @@
 
 @(heading: String, location: String)(implicit user: User[_])
 
-@if(user.session.get(SessionKeys.verifiedEmailDeprecated).isDefined | user.session.get(SessionKeys.preference).contains("no")) {
+@if(user.session.get(SessionKeys.verifiedEmail).isDefined | user.session.get(SessionKeys.preference).contains("no")) {
     <a href="@location" class="govuk-link">@heading</a>
 } else {
     <a href="@{controllers.agent.routes.CapturePreferenceController.show(location).url}" class="govuk-link">@heading</a>

--- a/it/pages/BasePageISpec.scala
+++ b/it/pages/BasePageISpec.scala
@@ -24,10 +24,14 @@ import play.api.test.Helpers.{INTERNAL_SERVER_ERROR, UNAUTHORIZED}
 
 trait BasePageISpec extends IntegrationBaseSpec {
 
-  def formatSessionVrn: Option[String] => Map[String, String] =_.fold(Map.empty[String, String])(x => Map(SessionKeys.clientVRNDeprecated -> x))
-  def formatPreference: Option[String] => Map[String, String] =_.fold(Map.empty[String, String])(x => Map(SessionKeys.preference -> x))
-  def formatNotificationsEmail: Option[String] => Map[String, String] =_.fold(Map.empty[String, String])(x => Map(SessionKeys.notificationsEmail -> x))
-  def formatVerifiedEmail: Option[String] => Map[String, String] =_.fold(Map.empty[String, String])(x => Map(SessionKeys.verifiedEmailDeprecated -> x))
+  def formatSessionVrn: Option[String] => Map[String, String] =
+    _.fold(Map.empty[String, String])(x => Map(SessionKeys.clientVRNDeprecated -> x))
+  def formatPreference: Option[String] => Map[String, String] =
+    _.fold(Map.empty[String, String])(x => Map(SessionKeys.preference -> x))
+  def formatNotificationsEmail: Option[String] => Map[String, String] =
+    _.fold(Map.empty[String, String])(x => Map(SessionKeys.notificationsEmail -> x))
+  def formatVerifiedEmail: Option[String] => Map[String, String] =
+    _.fold(Map.empty[String, String])(x => Map(SessionKeys.verifiedEmail -> x))
   def formatReturnUrl: Map[String, String] = Map(SessionKeys.redirectUrl -> "/homepage")
 
   def httpPostAuthenticationTests(path: String, sessionVrn: Option[String] = None)(formData: Map[String, Seq[String]]): Unit =

--- a/test/controllers/agent/ConfirmClientVrnControllerSpec.scala
+++ b/test/controllers/agent/ConfirmClientVrnControllerSpec.scala
@@ -118,7 +118,6 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
               }
 
               "add the client name to the session" in {
-                session(result).get(SessionKeys.clientNameDeprecated) shouldBe Some(customerDetailsOrganisation.clientName)
                 session(result).get(SessionKeys.clientName) shouldBe Some(customerDetailsOrganisation.clientName)
               }
             }
@@ -241,7 +240,6 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           }
 
           "remove the client name" in {
-            session(result).get(SessionKeys.clientNameDeprecated) shouldBe None
             session(result).get(SessionKeys.clientName) shouldBe None
           }
 
@@ -340,7 +338,6 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
               SessionKeys.clientVRNDeprecated -> vrn,
               SessionKeys.clientVRN -> vrn,
               SessionKeys.redirectUrl -> "/vat-through-software/account/change-something-about-vat",
-              SessionKeys.verifiedEmailDeprecated -> "an.email@host.com",
               SessionKeys.verifiedEmail -> "an.email@host.com"
             ))
           }
@@ -361,7 +358,6 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockCustome
           }
 
           "retain the agent email" in {
-            session(result).get(SessionKeys.verifiedEmailDeprecated) shouldBe Some("an.email@host.com")
             session(result).get(SessionKeys.verifiedEmail) shouldBe Some("an.email@host.com")
           }
         }

--- a/test/controllers/predicates/PreferencePredicateSpec.scala
+++ b/test/controllers/predicates/PreferencePredicateSpec.scala
@@ -84,7 +84,6 @@ class PreferencePredicateSpec extends ControllerBaseSpec with BeforeAndAfterAll 
 
           val agentWithPref = Agent(arn)(request.withSession(
             SessionKeys.preference -> "yes",
-            SessionKeys.verifiedEmailDeprecated -> "scala@gmail.com",
             SessionKeys.verifiedEmail -> "scala@gmail.com"
           ))
           await(mockPreferencePredicate.refine(agentWithPref)) shouldBe
@@ -98,7 +97,6 @@ class PreferencePredicateSpec extends ControllerBaseSpec with BeforeAndAfterAll 
 
           val agentWithPref = Agent(arn)(request.withSession(
             SessionKeys.preference -> "yes",
-            SessionKeys.verifiedEmailDeprecated -> "scala@gmail.com",
             SessionKeys.verifiedEmail -> "scala@gmail.com",
             SessionKeys.redirectUrl -> "/immafiringmuhlaserbwaaaaaaaaaaah"
           ))

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -63,7 +63,6 @@ trait TestUtil extends AnyWordSpecLike with Matchers with GuiceOneAppPerSuite wi
       SessionKeys.clientVRNDeprecated -> vrn,
       SessionKeys.clientVRN -> vrn,
       SessionKeys.redirectUrl -> "/homepage",
-      SessionKeys.clientNameDeprecated -> "l'biz",
       SessionKeys.clientName -> "l'biz",
       SessionKeys.mtdVatAgentMandationStatus -> nonMTDfB
     )

--- a/test/views/agent/partials/ClientDetailsPartialSpec.scala
+++ b/test/views/agent/partials/ClientDetailsPartialSpec.scala
@@ -59,9 +59,8 @@ class ClientDetailsPartialSpec extends ViewBaseSpec {
 
     "when the user has a valid agent email in session" should {
 
-      lazy val testGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "")
-        .withSession(SessionKeys.verifiedEmailDeprecated -> "exampleemail@email.com",
-          SessionKeys.verifiedEmail -> "exampleemail@email.com")
+      lazy val testGetRequest: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest("GET", "").withSession(SessionKeys.verifiedEmail -> "exampleemail@email.com")
 
       lazy val testuser: User[AnyContentAsEmpty.type] = User[AnyContentAsEmpty.type](vrn, active = true)(testGetRequest)
 

--- a/test/views/agent/partials/OptOutForMTDVATPartialSpec.scala
+++ b/test/views/agent/partials/OptOutForMTDVATPartialSpec.scala
@@ -57,9 +57,8 @@ class OptOutForMTDVATPartialSpec extends ViewBaseSpec {
 
       "agent has entered their contact preference" should {
 
-        lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "")
-          .withSession(SessionKeys.verifiedEmailDeprecated -> "exampleemail@email.com",
-            SessionKeys.verifiedEmail -> "exampleemail@email.com")
+        lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] =
+          FakeRequest("GET", "").withSession(SessionKeys.verifiedEmail -> "exampleemail@email.com")
         lazy val testUser: User[AnyContentAsEmpty.type] = User[AnyContentAsEmpty.type](vrn, active = true)(testGetRequest)
         lazy val view = optOutForMTDVATPartial("MTDfB Mandated")(messages, mockConfig, testUser)
         lazy implicit val document: Document = Jsoup.parse(view.body)

--- a/test/views/agent/partials/RegistrationPartialSpec.scala
+++ b/test/views/agent/partials/RegistrationPartialSpec.scala
@@ -90,11 +90,11 @@ class RegistrationPartialSpec extends ViewBaseSpec {
 
         "agent has entered their contact preference" should {
 
-          lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "")
-            .withSession(SessionKeys.verifiedEmailDeprecated -> "exampleemail@email.com",
-              SessionKeys.verifiedEmail -> "exampleemail@email.com")
+          lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] =
+            FakeRequest("GET", "").withSession(SessionKeys.verifiedEmail -> "exampleemail@email.com")
           lazy val testUser: User[AnyContentAsEmpty.type] = User[AnyContentAsEmpty.type](vrn, active = true)(testGetRequest)
-          lazy val view = registrationPartial(customerDetailsNoInfoWithPartyType, toLocalDate("2019-01-01"))(messages, mockConfig, testUser)
+          lazy val view =
+            registrationPartial(customerDetailsNoInfoWithPartyType, toLocalDate("2019-01-01"))(messages, mockConfig, testUser)
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
           "display a section for cancelling registration" which {
@@ -115,11 +115,11 @@ class RegistrationPartialSpec extends ViewBaseSpec {
 
         "agent has entered their contact preference, while the client is of partyType VatGroup" should {
 
-          lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "")
-            .withSession(SessionKeys.verifiedEmailDeprecated -> "exampleemail@email.com",
-              SessionKeys.verifiedEmail -> "exampleemail@email.com")
+          lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] =
+            FakeRequest("GET", "").withSession(SessionKeys.verifiedEmail -> "exampleemail@email.com")
           lazy val testUser: User[AnyContentAsEmpty.type] = User[AnyContentAsEmpty.type](vrn, active = true)(testGetRequest)
-          lazy val view = registrationPartial(customerDetailsNoInfoVatGroup, toLocalDate("2019-01-01"))(messages, mockConfig, testUser)
+          lazy val view =
+            registrationPartial(customerDetailsNoInfoVatGroup, toLocalDate("2019-01-01"))(messages, mockConfig, testUser)
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
           "display a section for cancelling registration" which {

--- a/test/views/helpers/CapturePreferenceHelperSpec.scala
+++ b/test/views/helpers/CapturePreferenceHelperSpec.scala
@@ -35,9 +35,8 @@ class CapturePreferenceHelperSpec extends ViewBaseSpec {
 
     "the agent has entered their email address" should {
 
-      lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "")
-        .withSession(SessionKeys.verifiedEmailDeprecated -> "exampleemail@email.com",
-          SessionKeys.verifiedEmail -> "exampleemail@email.com")
+      lazy implicit val testGetRequest: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest("GET", "").withSession(SessionKeys.verifiedEmail -> "exampleemail@email.com")
       lazy val testUser: User[AnyContentAsEmpty.type] = User[AnyContentAsEmpty.type](vrn, active = true)(testGetRequest)
       lazy val view: Html = capturePreferenceHelper("Heading", mockConfig.optOutMtdVatUrl)(testUser)
       lazy implicit val document: Document = Jsoup.parse(view.body)


### PR DESCRIPTION
Excluding CLIENT_VRN due to another team's service using it

This cannot be merged until all other services that use `mtdVatAgentClientName` and `verifiedAgentEmail` have switched over