### PR TITLE
BTAT-10659 Adding inputMode numeric on client VRN entry page

### DIFF
--- a/app/views/agent/SelectClientVrnView.scala.html
+++ b/app/views/agent/SelectClientVrnView.scala.html
@@ -46,6 +46,7 @@
     @govukInput(Input(
       id = "vrn",
       name = "vrn",
+      inputmode = Some("numeric"),
       label = Label(
         isPageHeading = true,
         classes = "govuk-label--l",
@@ -58,7 +59,9 @@
       errorMessage = form("vrn").error.map { err =>
         ErrorMessage(content = Text(messages(err.message)))
       },
-      classes = "govuk-input--width-10"
+      classes = "govuk-input--width-10",
+      pattern = Some("[0-9]*"),
+      spellcheck = Some(false)
     ))
 
     @govukButton(Button(


### PR DESCRIPTION
I used Browserstack to confirm that the numeric keyboard on a mobile device is displayed when the inout box has focus.